### PR TITLE
allow trailing whitespace in Markdown files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,4 +11,8 @@ end_of_line = lf
 indent_size = 2
 indent_style = space
 insert_final_newline = true
+trim_trailing_whitespace = true
+
+# allow trailing whitespace in Markdown files
+[*.md]
 trim_trailing_whitespace = false


### PR DESCRIPTION
But not for other files
