### PR TITLE
test-runner only (no execute)

### DIFF
--- a/parinfer-lib/dev/build.clj
+++ b/parinfer-lib/dev/build.clj
@@ -16,11 +16,20 @@
       (umd/flush-module "npm-publish/parinfer.js"))
   :done)
 
-(defn run-all-tests []
+(defn- test-setup []
   (-> (cljs/init-state)
       (cljs/set-build-options
         {:public-dir (io/file "target/cljs-tests")
          :public-path "target/cljs-tests"})
       (cljs/find-resources-in-classpath)
+      ))
+
+(defn test-runner []
+  (-> (test-setup)
+      (node/make-test-runner))
+  :done)
+
+(defn run-all-tests []
+  (-> (test-setup)
       (node/execute-all-tests!))
   :done)

--- a/parinfer-lib/dev/build.clj
+++ b/parinfer-lib/dev/build.clj
@@ -33,3 +33,18 @@
   (-> (test-setup)
       (node/execute-all-tests!))
   :done)
+
+(defn autotest
+  [& args]
+  (-> (test-setup)
+      (cljs/watch-and-repeat!
+        (fn [state modified]
+          (-> state
+              (cond->
+                ;; first pass, run all tests
+                (empty? modified)
+                (node/execute-all-tests!)
+                ;; only execute tests that might have been affected by the modified files
+                (not (empty? modified))
+                (node/execute-affected-tests! modified))
+              )))))

--- a/parinfer-lib/project.clj
+++ b/parinfer-lib/project.clj
@@ -15,6 +15,6 @@
   :profiles {:dev {:source-paths ["dev" "test"]
                    :dependencies [[org.clojure/clojure "1.7.0"]
                                   [org.clojure/clojurescript "1.7.170"]
-                                  [thheller/shadow-build "1.0.178"]]}}
+                                  [thheller/shadow-build "1.0.180"]]}}
 
   )


### PR DESCRIPTION
`lein run -m build/test-runner` to create the test runner without executing it.

`node target/cljs-tests/test-runner.js` to execute it. exit code 0 for success, 1 for error.
