### PR TITLE
Remove Object.preventExtensions

### DIFF
--- a/lib/parinfer.js
+++ b/lib/parinfer.js
@@ -136,11 +136,6 @@ function getInitialResult(text, options, mode) {
     errorPosCache: {}          // [object] - maps error name to a potential error position
   };
 
-  // make sure no new properties are added to result
-  // (for type safety)
-  Object.preventExtensions(result);
-  Object.preventExtensions(result.parenTrail);
-
   // merge options if they are valid
   if (options) {
     if (isInteger(options.cursorX))    { result.cursorX = options.cursorX; }


### PR DESCRIPTION
This seems to result in a [noticeable performance improvement](https://gist.github.com/oakmac/7639728fc162045c4f3b), particularly for `parenMode`.
