### PR TITLE
New Feature: output cursor

### DIFF
--- a/lib/README.md
+++ b/lib/README.md
@@ -145,6 +145,7 @@ Returns an object with the following properties:
 
 - `success` is a boolean indicating if the input was properly formatted enough to create a valid result
 - `text` is the full text output (this is just the original text if `success` is false)
+- `cursorX` is the new x-position of the cursor (since parinfer may shift it around)
 - `changedLines` is an array of objects representing only the lines which Parinfer changed:
   - `lineNo` is the zero-based line number
   - `line` is the full text of the line

--- a/lib/parinfer.js
+++ b/lib/parinfer.js
@@ -89,6 +89,7 @@ function getInitialResult(text, options, mode) {
     mode: mode,                // [enum] - current processing mode (INDENT_MODE or PAREN_MODE)
 
     origText: text,            // [string] - original text
+    origCursorX: SENTINEL_NULL,
     origLines:                 // [string array] - original lines
       text.split(LINE_ENDING_REGEX),
 
@@ -143,7 +144,7 @@ function getInitialResult(text, options, mode) {
 
   // merge options if they are valid
   if (options) {
-    if (isInteger(options.cursorX))    { result.cursorX = options.cursorX; }
+    if (isInteger(options.cursorX))    { result.cursorX = result.origCursorX = options.cursorX; }
     if (isInteger(options.cursorLine)) { result.cursorLine = options.cursorLine; }
     if (isInteger(options.cursorDx))   { result.cursorDx = options.cursorDx; }
   }
@@ -193,25 +194,10 @@ function error(result, errorName, lineNo, x) {
 // String Operations
 //------------------------------------------------------------------------------
 
-function insertWithinString(orig, idx, insert) {
-  return (
-    orig.substring(0, idx) +
-    insert +
-    orig.substring(idx)
-  );
-}
-
 function replaceWithinString(orig, start, end, replace) {
   return (
     orig.substring(0, start) +
     replace +
-    orig.substring(end)
-  );
-}
-
-function removeWithinString(orig, start, end) {
-  return (
-    orig.substring(0, start) +
     orig.substring(end)
   );
 }
@@ -239,19 +225,29 @@ function getLineEnding(text) {
 // Line operations
 //------------------------------------------------------------------------------
 
-function insertWithinLine(result, lineNo, idx, insert) {
-  var line = result.lines[lineNo];
-  result.lines[lineNo] = insertWithinString(line, idx, insert);
+function shiftCursorOnEdit(result, lineNo, start, end, replace) {
+  var oldLength = end - start;
+  var newLength = replace.length;
+  var dx = newLength - oldLength;
+
+  if (dx !== 0 &&
+      result.cursorLine === lineNo &&
+      result.cursorX !== SENTINEL_NULL &&
+      result.cursorX >= end) {
+    result.cursorX += dx;
+  }
 }
 
 function replaceWithinLine(result, lineNo, start, end, replace) {
   var line = result.lines[lineNo];
-  result.lines[lineNo] = replaceWithinString(line, start, end, replace);
+  var newLine = replaceWithinString(line, start, end, replace);
+  result.lines[lineNo] = newLine;
+
+  shiftCursorOnEdit(result, lineNo, start, end, replace);
 }
 
-function removeWithinLine(result, lineNo, start, end) {
-  var line = result.lines[lineNo];
-  result.lines[lineNo] = removeWithinString(line, start, end);
+function insertWithinLine(result, lineNo, idx, insert) {
+  replaceWithinLine(result, lineNo, idx, idx, insert);
 }
 
 function initLine(result, line) {
@@ -497,8 +493,8 @@ function clampParenTrailToCursor(result) {
   }
 }
 
-// INDENT MODE: removes the paren trail from the line
-function removeParenTrail(result) {
+// INDENT MODE: pops the paren trail from the stack
+function popParenTrail(result) {
   var startX = result.parenTrail.startX;
   var endX = result.parenTrail.endX;
 
@@ -510,8 +506,6 @@ function removeParenTrail(result) {
   while (openers.length !== 0) {
     result.parenStack.push(openers.pop());
   }
-
-  removeWithinLine(result, result.lineNo, startX, endX);
 }
 
 // INDENT MODE: correct paren trail from indentation
@@ -529,7 +523,7 @@ function correctParenTrail(result, indentX) {
     }
   }
 
-  insertWithinLine(result, result.parenTrail.lineNo, result.parenTrail.startX, parens);
+  replaceWithinLine(result, result.parenTrail.lineNo, result.parenTrail.startX, result.parenTrail.endX, parens);
 }
 
 // PAREN MODE: remove spaces from the paren trail
@@ -574,7 +568,7 @@ function appendParenTrail(result) {
 function finishNewParenTrail(result) {
   if (result.mode === INDENT_MODE) {
     clampParenTrailToCursor(result);
-    removeParenTrail(result);
+    popParenTrail(result);
   }
   else if (result.mode === PAREN_MODE) {
     if (result.lineNo !== result.cursorLine) {
@@ -774,6 +768,7 @@ function publicResult(result) {
   if (!result.success) {
     return {
       text: result.origText,
+      cursorX: result.origCursorX,
       success: false,
       error: result.error
     };
@@ -782,6 +777,7 @@ function publicResult(result) {
   var lineEnding = getLineEnding(result.origText);
   return {
     text: result.lines.join(lineEnding),
+    cursorX: result.cursorX,
     success: true,
     changedLines: getChangedLines(result)
   }

--- a/lib/test/cases.js
+++ b/lib/test/cases.js
@@ -28,8 +28,12 @@ function runMarkdownTestCase(testCase, mode, filename) {
   var options = cursor;
 
   it(filename + ":" + fileLineNo, function(){
-    var textOut = modeFn[mode](textIn, options).text;
+    var result = modeFn[mode](textIn, options);
+    var textOut = result.text;
     assert.strictEqual(textOut, textExpected);
+    if (options) {
+      assert.strictEqual(result.cursorX, testCase.out.cursor.cursorX);
+    }
 
     var textOut2 = modeFn[mode](textOut, options).text;
     assert.strictEqual(textOut2, textExpected, "idempotence");

--- a/lib/test/cases/build.js
+++ b/lib/test/cases/build.js
@@ -95,9 +95,6 @@ function parseLine_insideBlock(result, fileLineNo, line) {
 
   var cursorX = line.indexOf("|");
   if (cursorX !== -1) {
-    if (result.currLabel === "out") {
-      error(fileLineNo, "no cursor allowed in 'out' block yet");
-    }
     if (block.cursor !== null) {
       error(fileLineNo, "only one cursor allowed.  cursor already found at line", block.cursor.cursorLine);
     }

--- a/lib/test/cases/indent-mode.json
+++ b/lib/test/cases/indent-mode.json
@@ -267,7 +267,10 @@
       "lines": [
         "\"\"]\""
       ],
-      "cursor": null
+      "cursor": {
+        "cursorX": 1,
+        "cursorLine": 0
+      }
     }
   },
   {
@@ -292,7 +295,10 @@
         "  \"(a b)",
         "      c\")"
       ],
-      "cursor": null
+      "cursor": {
+        "cursorX": 3,
+        "cursorLine": 1
+      }
     }
   },
   {
@@ -315,7 +321,10 @@
         "  \"",
         "  [:div.td {:style \"max-width: 500px;\"}])"
       ],
-      "cursor": null
+      "cursor": {
+        "cursorX": 3,
+        "cursorLine": 1
+      }
     }
   },
   {
@@ -522,7 +531,10 @@
       "lines": [
         "(def b )"
       ],
-      "cursor": null
+      "cursor": {
+        "cursorX": 7,
+        "cursorLine": 0
+      }
     }
   },
   {
@@ -557,7 +569,10 @@
       "lines": [
         "(def b [[c d] ])"
       ],
-      "cursor": null
+      "cursor": {
+        "cursorX": 14,
+        "cursorLine": 0
+      }
     }
   },
   {
@@ -592,7 +607,10 @@
       "lines": [
         "(def b [[c d]])"
       ],
-      "cursor": null
+      "cursor": {
+        "cursorX": 5,
+        "cursorLine": 0
+      }
     }
   },
   {
@@ -631,7 +649,10 @@
         "(let [a 1])",
         "  ret"
       ],
-      "cursor": null
+      "cursor": {
+        "cursorX": 11,
+        "cursorLine": 0
+      }
     }
   },
   {
@@ -670,7 +691,10 @@
         "(let [a 1]",
         "  ret)"
       ],
-      "cursor": null
+      "cursor": {
+        "cursorX": 10,
+        "cursorLine": 0
+      }
     }
   },
   {
@@ -691,7 +715,10 @@
         "(let [a 1] ;",
         "  ret)"
       ],
-      "cursor": null
+      "cursor": {
+        "cursorX": 12,
+        "cursorLine": 0
+      }
     }
   },
   {
@@ -712,7 +739,78 @@
         "(let [a 1])",
         "      "
       ],
-      "cursor": null
+      "cursor": {
+        "cursorX": 6,
+        "cursorLine": 1
+      }
+    }
+  },
+  {
+    "in": {
+      "fileLineNo": 513,
+      "lines": [
+        "(foo ]] bar)"
+      ],
+      "cursor": {
+        "cursorX": 7,
+        "cursorLine": 0
+      }
+    },
+    "out": {
+      "fileLineNo": 517,
+      "lines": [
+        "(foo  bar)"
+      ],
+      "cursor": {
+        "cursorX": 5,
+        "cursorLine": 0
+      }
+    }
+  },
+  {
+    "in": {
+      "fileLineNo": 523,
+      "lines": [
+        "(foo bar ;)"
+      ],
+      "cursor": {
+        "cursorX": 10,
+        "cursorLine": 0
+      }
+    },
+    "out": {
+      "fileLineNo": 527,
+      "lines": [
+        "(foo bar) ;)"
+      ],
+      "cursor": {
+        "cursorX": 11,
+        "cursorLine": 0
+      }
+    }
+  },
+  {
+    "in": {
+      "fileLineNo": 533,
+      "lines": [
+        "(let [x 1",
+        "      y 2;])"
+      ],
+      "cursor": {
+        "cursorX": 10,
+        "cursorLine": 1
+      }
+    },
+    "out": {
+      "fileLineNo": 538,
+      "lines": [
+        "(let [x 1",
+        "      y 2]);])"
+      ],
+      "cursor": {
+        "cursorX": 12,
+        "cursorLine": 1
+      }
     }
   }
 ]

--- a/lib/test/cases/indent-mode.md
+++ b/lib/test/cases/indent-mode.md
@@ -194,7 +194,7 @@ out, causing Parinfer to treat its contents as code).
 ```
 
 ```out
-""]"
+"|"]"
 ```
 
 Another case:
@@ -208,7 +208,7 @@ Another case:
 
 ```out
 (def foo
-  "
+  "|
   "(a b)
       c")
 ```
@@ -230,7 +230,7 @@ odd number of quotes (one):
 
 ```out
 (for [col columns]
-  "
+  "|
   [:div.td {:style "max-width: 500px;"}])
 ```
 
@@ -385,7 +385,7 @@ This allows us to insert a space before typing a new token.
 ```
 
 ```out
-(def b )
+(def b |)
 ```
 
 Once the cursor leaves the line, the space is removed.
@@ -405,7 +405,7 @@ Another example with more close-parens:
 ```
 
 ```out
-(def b [[c d] ])
+(def b [[c d] |])
 ```
 
 Once the cursor leaves the line, the space is removed.
@@ -426,7 +426,7 @@ cursor is to the left of the gaps.
 ```
 
 ```out
-(def b [[c d]])
+(def |b [[c d]])
 ```
 
 Inferred close-parens before the cursor are never removed, which may
@@ -453,7 +453,7 @@ With the cursor at the end of the first line, the indented line below does not a
 ```
 
 ```out
-(let [a 1])
+(let [a 1])|
   ret
 ```
 
@@ -479,7 +479,7 @@ insert a token after it, thus indentation can affect it again:
 ```
 
 ```out
-(let [a 1]
+(let [a 1]|
   ret)
 ```
 
@@ -491,7 +491,7 @@ If the cursor is in a comment after such a close-paren, we can safely move it:
 ```
 
 ```out
-(let [a 1] ;
+(let [a 1] ;|
   ret)
 ```
 
@@ -506,6 +506,37 @@ they were.
 
 ```out
 (let [a 1])
-      
+      |
 ```
 
+Removing invalid close-parens should pull back the cursor
+
+```in
+(foo ]]| bar)
+```
+
+```out
+(foo | bar)
+```
+
+Commenting an inferred close-paren
+
+```in
+(foo bar ;|)
+```
+
+```out
+(foo bar) ;|)
+```
+
+Commenting multiple inferred close-parens
+
+```in
+(let [x 1
+      y 2;|])
+```
+
+```out
+(let [x 1
+      y 2]);|])
+```

--- a/lib/test/cases/paren-mode.json
+++ b/lib/test/cases/paren-mode.json
@@ -291,7 +291,10 @@
       "lines": [
         "(foo )"
       ],
-      "cursor": null
+      "cursor": {
+        "cursorX": 5,
+        "cursorLine": 0
+      }
     }
   },
   {
@@ -310,7 +313,10 @@
       "lines": [
         "(foo [1 2 3 ] )"
       ],
-      "cursor": null
+      "cursor": {
+        "cursorX": 12,
+        "cursorLine": 0
+      }
     }
   },
   {
@@ -363,7 +369,58 @@
         "(foo [a b",
         "      ])"
       ],
-      "cursor": null
+      "cursor": {
+        "cursorX": 6,
+        "cursorLine": 1
+      }
+    }
+  },
+  {
+    "in": {
+      "fileLineNo": 259,
+      "lines": [
+        "(foo [1 2 3",
+        " 4 5 6",
+        " 7 8 9])"
+      ],
+      "cursor": {
+        "cursorX": 8,
+        "cursorLine": 2
+      }
+    },
+    "out": {
+      "fileLineNo": 265,
+      "lines": [
+        "(foo [1 2 3",
+        "      4 5 6",
+        "      7 8 9])"
+      ],
+      "cursor": {
+        "cursorX": 13,
+        "cursorLine": 2
+      }
+    }
+  },
+  {
+    "in": {
+      "fileLineNo": 273,
+      "lines": [
+        "(foo ]] bar)"
+      ],
+      "cursor": {
+        "cursorX": 7,
+        "cursorLine": 0
+      }
+    },
+    "out": {
+      "fileLineNo": 277,
+      "lines": [
+        "(foo  bar)"
+      ],
+      "cursor": {
+        "cursorX": 5,
+        "cursorLine": 0
+      }
     }
   }
 ]

--- a/lib/test/cases/paren-mode.md
+++ b/lib/test/cases/paren-mode.md
@@ -212,7 +212,7 @@ to insert things between close-parens more easily.
 ```
 
 ```out
-(foo )
+(foo |)
 ```
 
 ```in
@@ -220,7 +220,7 @@ to insert things between close-parens more easily.
 ```
 
 ```out
-(foo [1 2 3 ] )
+(foo [1 2 3 |] )
 ```
 
 But get rid of spaces in paren trail if no cursor is present on the line:
@@ -243,7 +243,7 @@ But get rid of spaces in paren trail if no cursor is present on the line:
 
 ## Cursor Behavior
 
-cursor before a close-paren allows it to be at the start of a line.
+Pressing enter before a close-paren.
 
 ```in
 (foo [a b
@@ -252,6 +252,29 @@ cursor before a close-paren allows it to be at the start of a line.
 
 ```out
 (foo [a b
-      ])
+      |])
 ```
 
+Cursor pushed forward when a form is balanced and indented.
+
+```in
+(foo [1 2 3
+ 4 5 6
+ 7 8 9])|
+```
+
+```out
+(foo [1 2 3
+      4 5 6
+      7 8 9])|
+```
+
+Move cursor back after typing invalid characters
+
+```in
+(foo ]]| bar)
+```
+
+```out
+(foo | bar)
+```


### PR DESCRIPTION
This new feature allows Parinfer to return the position of the cursor.  Fixes #47 

I created a commit per change type (i.e. code, tester, cases, doc) to make the diffs easier to read for porting.
