### PR TITLE
New Option: Cursor Scope in Indent Mode

### DIFF
--- a/lib/parinfer.js
+++ b/lib/parinfer.js
@@ -643,6 +643,12 @@ function onIndent(result) {
 function onLeadingCloseParen(result) {
   result.skipChar = true;
 
+  if (result.mode === INDENT_MODE) {
+    if (result.indentAtCursor) {
+      result.skipChar = false;
+      result.ch = BLANK_SPACE;
+    }
+  }
   if (result.mode === PAREN_MODE) {
     if (isValidCloseParen(result.parenStack, result.ch)) {
       if (isCursorOnLeft(result)) {

--- a/lib/parinfer.js
+++ b/lib/parinfer.js
@@ -120,6 +120,7 @@ function getInitialResult(text, options, mode) {
     cursorLine: SENTINEL_NULL, // [integer] - line number of the cursor
     cursorDx: SENTINEL_NULL,   // [integer] - amount that the cursor moved horizontally if something was inserted or deleted
     previewCursorScope: false, // [boolean] - preview the cursor's scope by showing the Paren Trail after it (on an empty line)
+    indentAtCursor: false,     // [boolean] - determines if the current line will be transformed for `previewCursorScope`
 
     isInCode: true,            // [boolean] - indicates if we are currently in "code space" (not string or comment)
     isEscaping: false,         // [boolean] - indicates if the next character will be escaped (e.g. `\c`).  This may be inside string, comment, or code.

--- a/lib/parinfer.js
+++ b/lib/parinfer.js
@@ -51,6 +51,9 @@ var BACKSLASH = '\\',
 
 var LINE_ENDING_REGEX = /\r?\n/;
 
+// determines if a line only contains a Paren Trail (possibly w/ a comment)
+var STANDALONE_PAREN_TRAIL = /^[\s\]\)\}]*(;.*)?$/
+
 var PARENS = {
   "{": "}",
   "}": "{",
@@ -59,6 +62,10 @@ var PARENS = {
   "(": ")",
   ")": "("
 };
+
+function isBoolean(x) {
+  return typeof x === 'boolean';
+}
 
 function isInteger(x) {
   return typeof x === 'number' &&
@@ -112,6 +119,7 @@ function getInitialResult(text, options, mode) {
     cursorX: SENTINEL_NULL,    // [integer] - x position of the cursor
     cursorLine: SENTINEL_NULL, // [integer] - line number of the cursor
     cursorDx: SENTINEL_NULL,   // [integer] - amount that the cursor moved horizontally if something was inserted or deleted
+    previewCursorScope: false, // [boolean] - preview the cursor's scope by showing the Paren Trail after it (on an empty line)
 
     isInCode: true,            // [boolean] - indicates if we are currently in "code space" (not string or comment)
     isEscaping: false,         // [boolean] - indicates if the next character will be escaped (e.g. `\c`).  This may be inside string, comment, or code.
@@ -144,9 +152,11 @@ function getInitialResult(text, options, mode) {
 
   // merge options if they are valid
   if (options) {
-    if (isInteger(options.cursorX))    { result.cursorX = result.origCursorX = options.cursorX; }
-    if (isInteger(options.cursorLine)) { result.cursorLine = options.cursorLine; }
-    if (isInteger(options.cursorDx))   { result.cursorDx = options.cursorDx; }
+    if (isInteger(options.cursorX))            { result.cursorX            = options.cursorX;
+                                                 result.origCursorX        = options.cursorX; }
+    if (isInteger(options.cursorLine))         { result.cursorLine         = options.cursorLine; }
+    if (isInteger(options.cursorDx))           { result.cursorDx           = options.cursorDx; }
+    if (isBoolean(options.previewCursorScope)) { result.previewCursorScope = options.previewCursorScope; }
   }
 
   return result;
@@ -447,6 +457,14 @@ function handleCursorDelta(result) {
 // Paren Trail functions
 //------------------------------------------------------------------------------
 
+function resetParenTrail(result, lineNo, x) {
+  result.parenTrail.lineNo = lineNo;
+  result.parenTrail.startX = x;
+  result.parenTrail.endX = x;
+  result.parenTrail.openers = [];
+  result.maxIndent = SENTINEL_NULL;
+}
+
 // update the head of the paren trail as we scan each character.
 // NOTE: `onMatchedCloseParen` modifies the endX
 function updateParenTrailBounds(result) {
@@ -464,11 +482,7 @@ function updateParenTrailBounds(result) {
   );
 
   if (shouldReset) {
-    result.parenTrail.lineNo = result.lineNo;
-    result.parenTrail.startX = result.x + 1;
-    result.parenTrail.endX = result.x + 1;
-    result.parenTrail.openers = [];
-    result.maxIndent = SENTINEL_NULL;
+    resetParenTrail(result, result.lineNo, result.x+1);
   }
 }
 
@@ -611,7 +625,7 @@ function correctIndent(result) {
   }
 }
 
-function onProperIndent(result) {
+function onIndent(result) {
   result.trackingIndent = false;
 
   if (result.quoteDanger) {
@@ -628,13 +642,12 @@ function onProperIndent(result) {
 
 function onLeadingCloseParen(result) {
   result.skipChar = true;
-  result.trackingIndent = true;
 
   if (result.mode === PAREN_MODE) {
     if (isValidCloseParen(result.parenStack, result.ch)) {
       if (isCursorOnLeft(result)) {
         result.skipChar = false;
-        onProperIndent(result);
+        onIndent(result);
       }
       else {
         appendParenTrail(result);
@@ -643,16 +656,45 @@ function onLeadingCloseParen(result) {
   }
 }
 
-function onIndent(result) {
-  if (isCloseParen(result.ch)) {
+function checkIndent(result) {
+
+  // treat cursor as indentation point under special circumstances
+  if (result.indentAtCursor && result.cursorX === result.x) {
+    onIndent(result);
+    resetParenTrail(result, result.lineNo, result.x);
+  }
+  else if (isCloseParen(result.ch)) {
     onLeadingCloseParen(result);
   }
   else if (result.ch === SEMICOLON) {
     // comments don't count as indentation points
     result.trackingIndent = false;
   }
-  else if (result.ch !== NEWLINE) {
-    onProperIndent(result);
+  else if (result.ch !== NEWLINE &&
+           result.ch !== BLANK_SPACE &&
+           result.ch !== TAB) {
+    onIndent(result);
+  }
+}
+
+function initIndent(result) {
+  if (result.mode === INDENT_MODE) {
+    result.trackingIndent = (
+      result.parenStack.length !== 0 &&
+      !result.isInStr
+    );
+
+    var semicolonX = result.lines[result.lineNo].indexOf(";");
+    result.indentAtCursor = (
+      result.previewCursorScope &&
+      result.trackingIndent &&
+      result.cursorLine === result.lineNo &&
+      STANDALONE_PAREN_TRAIL.test(result.lines[result.lineNo]) &&
+      (semicolonX === -1 || result.cursorX <= semicolonX)
+    );
+  }
+  else if (result.mode === PAREN_MODE) {
+    result.trackingIndent = !result.isInStr;
   }
 }
 
@@ -670,8 +712,8 @@ function processChar(result, ch) {
     handleCursorDelta(result);
   }
 
-  if (result.trackingIndent && ch !== BLANK_SPACE && ch !== TAB) {
-    onIndent(result);
+  if (result.trackingIndent) {
+    checkIndent(result);
   }
 
   if (result.skipChar) {
@@ -687,16 +729,7 @@ function processChar(result, ch) {
 
 function processLine(result, line) {
   initLine(result, line);
-
-  if (result.mode === INDENT_MODE) {
-    result.trackingIndent = (
-      result.parenStack.length !== 0 &&
-      !result.isInStr
-    );
-  }
-  else if (result.mode === PAREN_MODE) {
-    result.trackingIndent = !result.isInStr;
-  }
+  initIndent(result);
 
   var i;
   var chars = line + NEWLINE;

--- a/lib/parinfer.js.md
+++ b/lib/parinfer.js.md
@@ -44,6 +44,7 @@ Thus, we cover the design and implementation of Parinfer in two parts:
 
 - [The Cursor in Indent Mode](#the-cursor-in-indent-mode)
 - [The Cursor in Paren Mode](#the-cursor-in-paren-mode)
+- [Seeing Cursor Scope in Indent Mode](#seeing-cursor-scope-in-indent-mode)
 - [Correcting the Cursor Position](#correcting-the-cursor-position)
 - [Preserving Relative Indentation while typing](#preserving-relative-indentation-while-typing)
 - [Dangerous Quotes](#dangerous-quotes)
@@ -758,6 +759,216 @@ And again, it's important to note that simply moving the cursor to another line
 will reformat the line that was "suspended" by this cursor rule, restoring the
 full rules of Paren Mode.
 
+### Seeing Cursor Scope in Indent Mode
+
+In Indent Mode, when a user has their cursor on an empty line, it may be useful
+for them to always see the "scope" of the cursor.  For example, if we had
+the cursor here:
+
+```clj
+(let [foo 1
+      bar 2])
+  |
+```
+
+It may be more beneficial for the user to see this, so that it's clear where
+text will be inserted before ever typing it:
+
+```clj
+(let [foo 1
+      bar 2]
+  |)
+```
+
+For another example:
+
+```clj
+(let [foo 1
+      bar 2|])
+```
+
+If the user presses Enter, and if the editor auto-indents correctly, they will
+see this:
+
+```clj
+(let [foo 1
+      bar 2
+      |])
+```
+
+And if we move the cursor back a bit...
+
+```clj
+(let [foo 1
+      bar 2
+  |    ])
+```
+
+...the text will be transformed to accomodate the new cursor position:
+
+```clj
+(let [foo 1
+      bar 2]
+  |)
+```
+
+And finally, when moving the cursor to another line, normal formatting rules apply:
+
+```clj
+(let [foo 1
+      bar 2])
+```
+
+It's not technically necessary to apply this special rule for the cursor since
+typing would reveal the same close-parens anyway. Nonetheless, it is both a
+useful UX option and one that can be implemented in a manner consistent to
+Parinfer's system.
+
+_See [`result.previewCursorScope`] to enable._
+
+--
+
+__Implementation-wise__, we define this as a special rule which only applies to
+_lines containing whitespace, close-parens, or comments_.  If a cursor is found
+on such a line and the cursor is not inside a comment, then [`initIndent`] will
+set [`result.indentAtCursor`] to `true` to proceed.
+
+[`checkIndent`] will then treat the cursor as an indentation point AND the
+start of a new Paren Trail.  Everything else falls into place based on the
+usual rules of Indent Mode, but here's more exposition if you want examples.
+
+For example, we have a cursor on an empty line:
+
+```clj
+(let [foo 1
+      bar 2])
+      |
+```
+
+Since the last line is only whitespace, it matches our special rule's pattern.
+So we now consider the left of the cursor as indentation and the right of the
+cursor as a Paren Trail.  Using our overloaded underscore notation to label
+this:
+
+```clj
+(let [foo 1
+      bar 2])
+______|_
+```
+
+Following the rules of Indent Mode means that once the indentation point is found (at the
+cursor now), the previous Paren Trail is corrected, so let's mark the previous Paren Trail:
+
+```clj
+(let [foo 1
+      bar 2])
+           ^^
+______|_
+```
+
+By existing Indent Mode rules, the Paren Trail is erased due to the indentation threshold:
+
+```clj
+(let [foo 1
+      bar 2_
+______|_
+```
+
+Next, the empty Paren Trail after the cursor will be corrected to:
+
+```clj
+(let [foo 1
+      bar 2_
+______|])
+       ^^
+```
+
+Removing the annotations to see the final result:
+
+```clj
+(let [foo 1
+      bar 2
+      |])
+```
+
+For the next example, we will suppose that the user moves the cursor to
+the left a few spaces in the previous example:
+
+```clj
+(let [foo 1
+      bar 2
+  |    ])
+```
+
+Since the last line still matches our special rule's pattern, we can apply our
+new cursor rules:  left indentation, right Paren Trail.
+
+```clj
+(let [foo 1
+      bar 2_
+__|    ])
+   ^^^^^^
+```
+
+Proceeding exactly as before, we end with the following:
+
+```clj
+(let [foo 1
+      bar 2]
+           ^
+__|)
+   ^
+```
+
+```clj
+(let [foo 1
+      bar 2]
+  |)
+```
+
+For the final example, we will suppose the user moves the cursor to the right
+in the previous example:
+
+```clj
+(let [foo 1
+      bar 2]
+   )|
+```
+
+Since the line still matches the special rule's pattern, we can apply our new labels as before:
+
+```clj
+(let [foo 1
+      bar 2]
+___)|_
+```
+
+Any close-paren caught in the indentation area before the cursor will be
+converted to whitespace rather than removed.  This allow the cursor to remain
+in its position rather than be pulled back, which would revert this whole process.
+See [`onLeadingCloseParen`] to see where this happens.
+
+```clj
+(let [foo 1
+      bar 2]
+____|_
+```
+
+Finally, everything proceeds as before so that we have:
+
+```clj
+(let [foo 1
+      bar 2]
+____|)
+     ^
+```
+
+```clj
+(let [foo 1
+      bar 2]
+    |)
+```
+
 ### Preserving Relative Indentation while typing
 
 Unfortunately, Paren Mode needs extra help to preserve relative indentation
@@ -969,7 +1180,7 @@ to be commented without triggering a warning:
 Detection of dangerous quotes inside comments is done simply by toggling
 [`result.quoteDanger`] everytime an unescaped quote is encountered inside a
 comment.  This happens in [`onQuote`], and we check if an error should be
-reported at [`onProperIndent`] since that moment signifies that no contiguous
+reported at [`onIndent`] since that moment signifies that no contiguous
 comments follow.
 
 --
@@ -1007,81 +1218,99 @@ chatroom].  I'll answer questions as soon as I can.
 [gitter chatroom]:https://gitter.im/shaunlebron/parinfer
 
 <!-- END OF DOC: All content below is overwritten by `update-doc-reflinks.sh` -->
-[`isInteger`]:parinfer.js#L63
-[`isOpenParen`]:parinfer.js#L69
-[`isCloseParen`]:parinfer.js#L73
-[`getInitialResult`]:parinfer.js#L85
-[`cacheErrorPos`]:parinfer.js#L172
-[`error`]:parinfer.js#L176
-[`replaceWithinString`]:parinfer.js#L197
-[`repeatString`]:parinfer.js#L205
-[`getLineEnding`]:parinfer.js#L214
-[`isCursorAffected`]:parinfer.js#L228
-[`shiftCursorOnEdit`]:parinfer.js#L236
-[`replaceWithinLine`]:parinfer.js#L249
-[`insertWithinLine`]:parinfer.js#L257
-[`initLine`]:parinfer.js#L261
-[`commitChar`]:parinfer.js#L272
-[`clamp`]:parinfer.js#L284
-[`peek`]:parinfer.js#L294
-[`isValidCloseParen`]:parinfer.js#L305
-[`onOpenParen`]:parinfer.js#L312
-[`onMatchedCloseParen`]:parinfer.js#L323
-[`onUnmatchedCloseParen`]:parinfer.js#L331
-[`onCloseParen`]:parinfer.js#L335
-[`onTab`]:parinfer.js#L346
-[`onSemicolon`]:parinfer.js#L352
-[`onNewline`]:parinfer.js#L359
-[`onQuote`]:parinfer.js#L364
-[`onBackslash`]:parinfer.js#L380
-[`afterBackslash`]:parinfer.js#L384
-[`onChar`]:parinfer.js#L395
-[`isCursorOnLeft`]:parinfer.js#L413
-[`isCursorOnRight`]:parinfer.js#L421
-[`isCursorInComment`]:parinfer.js#L430
-[`handleCursorDelta`]:parinfer.js#L434
-[`updateParenTrailBounds`]:parinfer.js#L452
-[`clampParenTrailToCursor`]:parinfer.js#L476
-[`popParenTrail`]:parinfer.js#L505
-[`correctParenTrail`]:parinfer.js#L520
-[`cleanParenTrail`]:parinfer.js#L538
-[`appendParenTrail`]:parinfer.js#L567
-[`finishNewParenTrail`]:parinfer.js#L576
-[`correctIndent`]:parinfer.js#L592
-[`onProperIndent`]:parinfer.js#L614
-[`onLeadingCloseParen`]:parinfer.js#L629
-[`onIndent`]:parinfer.js#L646
-[`processChar`]:parinfer.js#L663
-[`processLine`]:parinfer.js#L688
-[`finalizeResult`]:parinfer.js#L712
-[`processError`]:parinfer.js#L728
-[`processText`]:parinfer.js#L740
-[`getChangedLines`]:parinfer.js#L761
-[`publicResult`]:parinfer.js#L775
-[`indentMode`]:parinfer.js#L794
-[`parenMode`]:parinfer.js#L799
-[`result.mode`]:parinfer.js#L89
-[`result.origText`]:parinfer.js#L91
-[`result.origLines`]:parinfer.js#L93
-[`result.lines`]:parinfer.js#L96
-[`result.lineNo`]:parinfer.js#L97
-[`result.ch`]:parinfer.js#L98
-[`result.x`]:parinfer.js#L99
-[`result.parenStack`]:parinfer.js#L101
-[`result.parenTrail`]:parinfer.js#L105
-[`result.cursorX`]:parinfer.js#L112
-[`result.cursorLine`]:parinfer.js#L113
-[`result.cursorDx`]:parinfer.js#L114
-[`result.isInCode`]:parinfer.js#L116
-[`result.isEscaping`]:parinfer.js#L117
-[`result.isInStr`]:parinfer.js#L118
-[`result.isInComment`]:parinfer.js#L119
-[`result.commentX`]:parinfer.js#L120
-[`result.quoteDanger`]:parinfer.js#L122
-[`result.trackingIndent`]:parinfer.js#L123
-[`result.skipChar`]:parinfer.js#L124
-[`result.success`]:parinfer.js#L125
-[`result.maxIndent`]:parinfer.js#L127
-[`result.indentDelta`]:parinfer.js#L128
-[`result.error`]:parinfer.js#L131
-[`result.errorPosCache`]:parinfer.js#L137
+[`SENTINEL_NULL`]:parinfer.js#L39
+[`INDENT_MODE`]:parinfer.js#L41
+[`BACKSLASH`]:parinfer.js#L44
+[`LINE_ENDING_REGEX`]:parinfer.js#L52
+[`STANDALONE_PAREN_TRAIL`]:parinfer.js#L55
+[`PARENS`]:parinfer.js#L57
+[`ERROR_QUOTE_DANGER`]:parinfer.js#L171
+[`ERROR_EOL_BACKSLASH`]:parinfer.js#L172
+[`ERROR_UNCLOSED_QUOTE`]:parinfer.js#L173
+[`ERROR_UNCLOSED_PAREN`]:parinfer.js#L174
+[`ERROR_UNHANDLED`]:parinfer.js#L175
+[`errorMessages`]:parinfer.js#L177
+[`API`]:parinfer.js#L844
+[`isBoolean`]:parinfer.js#L66
+[`isInteger`]:parinfer.js#L70
+[`isOpenParen`]:parinfer.js#L76
+[`isCloseParen`]:parinfer.js#L80
+[`getInitialResult`]:parinfer.js#L92
+[`cacheErrorPos`]:parinfer.js#L183
+[`error`]:parinfer.js#L187
+[`replaceWithinString`]:parinfer.js#L208
+[`repeatString`]:parinfer.js#L216
+[`getLineEnding`]:parinfer.js#L225
+[`isCursorAffected`]:parinfer.js#L239
+[`shiftCursorOnEdit`]:parinfer.js#L247
+[`replaceWithinLine`]:parinfer.js#L260
+[`insertWithinLine`]:parinfer.js#L268
+[`initLine`]:parinfer.js#L272
+[`commitChar`]:parinfer.js#L283
+[`clamp`]:parinfer.js#L295
+[`peek`]:parinfer.js#L305
+[`isValidCloseParen`]:parinfer.js#L316
+[`onOpenParen`]:parinfer.js#L323
+[`onMatchedCloseParen`]:parinfer.js#L334
+[`onUnmatchedCloseParen`]:parinfer.js#L342
+[`onCloseParen`]:parinfer.js#L346
+[`onTab`]:parinfer.js#L357
+[`onSemicolon`]:parinfer.js#L363
+[`onNewline`]:parinfer.js#L370
+[`onQuote`]:parinfer.js#L375
+[`onBackslash`]:parinfer.js#L391
+[`afterBackslash`]:parinfer.js#L395
+[`onChar`]:parinfer.js#L406
+[`isCursorOnLeft`]:parinfer.js#L424
+[`isCursorOnRight`]:parinfer.js#L432
+[`isCursorInComment`]:parinfer.js#L441
+[`handleCursorDelta`]:parinfer.js#L445
+[`resetParenTrail`]:parinfer.js#L461
+[`updateParenTrailBounds`]:parinfer.js#L471
+[`clampParenTrailToCursor`]:parinfer.js#L491
+[`popParenTrail`]:parinfer.js#L520
+[`correctParenTrail`]:parinfer.js#L535
+[`cleanParenTrail`]:parinfer.js#L553
+[`appendParenTrail`]:parinfer.js#L582
+[`finishNewParenTrail`]:parinfer.js#L591
+[`correctIndent`]:parinfer.js#L607
+[`onIndent`]:parinfer.js#L629
+[`onLeadingCloseParen`]:parinfer.js#L644
+[`checkIndent`]:parinfer.js#L666
+[`initIndent`]:parinfer.js#L687
+[`processChar`]:parinfer.js#L712
+[`processLine`]:parinfer.js#L737
+[`finalizeResult`]:parinfer.js#L752
+[`processError`]:parinfer.js#L768
+[`processText`]:parinfer.js#L780
+[`getChangedLines`]:parinfer.js#L801
+[`publicResult`]:parinfer.js#L815
+[`indentMode`]:parinfer.js#L834
+[`parenMode`]:parinfer.js#L839
+[`result.mode`]:parinfer.js#L96
+[`result.origText`]:parinfer.js#L98
+[`result.origLines`]:parinfer.js#L100
+[`result.lines`]:parinfer.js#L103
+[`result.lineNo`]:parinfer.js#L104
+[`result.ch`]:parinfer.js#L105
+[`result.x`]:parinfer.js#L106
+[`result.parenStack`]:parinfer.js#L108
+[`result.parenTrail`]:parinfer.js#L112
+[`result.cursorX`]:parinfer.js#L119
+[`result.cursorLine`]:parinfer.js#L120
+[`result.cursorDx`]:parinfer.js#L121
+[`result.previewCursorScope`]:parinfer.js#L122
+[`result.indentAtCursor`]:parinfer.js#L123
+[`result.isInCode`]:parinfer.js#L125
+[`result.isEscaping`]:parinfer.js#L126
+[`result.isInStr`]:parinfer.js#L127
+[`result.isInComment`]:parinfer.js#L128
+[`result.commentX`]:parinfer.js#L129
+[`result.quoteDanger`]:parinfer.js#L131
+[`result.trackingIndent`]:parinfer.js#L132
+[`result.skipChar`]:parinfer.js#L133
+[`result.success`]:parinfer.js#L134
+[`result.maxIndent`]:parinfer.js#L136
+[`result.indentDelta`]:parinfer.js#L137
+[`result.error`]:parinfer.js#L140
+[`result.errorPosCache`]:parinfer.js#L146

--- a/lib/test/cases/build.js
+++ b/lib/test/cases/build.js
@@ -127,9 +127,22 @@ function handleErrorLine(result, block, fileLineNo, name, x) {
   return true;
 }
 
+function handleCursorPreviewScope(result, block, fileLineNo, x) {
+  if (result.currLabel === "out") {
+    error(fileLineNo, "no ^ previewCursorScope annotation allowed in output block.");
+  }
+  if (block.cursor === null || block.cursor.cursorX !== x) {
+    error(fileLineNo, "the ^ previewCursorScope annotation does not point to a cursor.");
+  }
+
+  block.cursor.previewCursorScope = true;
+  return true;
+}
+
 function handleCaretLine(result, block, fileLineNo, line) {
   var errorMatch = /^\s*\^\s*([a-z-]+)$/.exec(line);
   var cursorDxMatch = /^\s*\^\s*cursorDx (-?\d+)\s*$/.exec(line);
+  var cursorPreviewScopeMatch = /^\s*\^\spreviewCursorScope\s*$/.exec(line);
   var x = line.indexOf("^");
 
   if (errorMatch) {
@@ -139,6 +152,9 @@ function handleCaretLine(result, block, fileLineNo, line) {
   else if (cursorDxMatch) {
     var cursorDx = parseInt(cursorDxMatch[1]);
     return handleCursorDxLine(result, block, fileLineNo, cursorDx, x);
+  }
+  else if (cursorPreviewScopeMatch) {
+    return handleCursorPreviewScope(result, block, fileLineNo, x);
   }
 
   return false;

--- a/lib/test/cases/indent-mode.json
+++ b/lib/test/cases/indent-mode.json
@@ -876,7 +876,32 @@
   },
   {
     "in": {
-      "fileLineNo": 578,
+      "fileLineNo": 577,
+      "lines": [
+        "(let [a 1]",
+        " )"
+      ],
+      "cursor": {
+        "cursorX": 2,
+        "cursorLine": 1,
+        "previewCursorScope": true
+      }
+    },
+    "out": {
+      "fileLineNo": 583,
+      "lines": [
+        "(let [a 1]",
+        "  )"
+      ],
+      "cursor": {
+        "cursorX": 2,
+        "cursorLine": 1
+      }
+    }
+  },
+  {
+    "in": {
+      "fileLineNo": 591,
       "lines": [
         "(let [a 1",
         "      ] b)"
@@ -888,7 +913,7 @@
       }
     },
     "out": {
-      "fileLineNo": 584,
+      "fileLineNo": 597,
       "lines": [
         "(let [a 1",
         "       b])"
@@ -901,7 +926,7 @@
   },
   {
     "in": {
-      "fileLineNo": 597,
+      "fileLineNo": 610,
       "lines": [
         "(foo ]] bar)"
       ],
@@ -911,7 +936,7 @@
       }
     },
     "out": {
-      "fileLineNo": 601,
+      "fileLineNo": 614,
       "lines": [
         "(foo  bar)"
       ],
@@ -923,7 +948,7 @@
   },
   {
     "in": {
-      "fileLineNo": 607,
+      "fileLineNo": 620,
       "lines": [
         "(foo bar ;)"
       ],
@@ -933,7 +958,7 @@
       }
     },
     "out": {
-      "fileLineNo": 611,
+      "fileLineNo": 624,
       "lines": [
         "(foo bar) ;)"
       ],
@@ -945,7 +970,7 @@
   },
   {
     "in": {
-      "fileLineNo": 617,
+      "fileLineNo": 630,
       "lines": [
         "(let [x 1",
         "      y 2;])"
@@ -956,7 +981,7 @@
       }
     },
     "out": {
-      "fileLineNo": 622,
+      "fileLineNo": 635,
       "lines": [
         "(let [x 1",
         "      y 2]);])"
@@ -969,7 +994,7 @@
   },
   {
     "in": {
-      "fileLineNo": 629,
+      "fileLineNo": 642,
       "lines": [
         "("
       ],
@@ -979,7 +1004,7 @@
       }
     },
     "out": {
-      "fileLineNo": 633,
+      "fileLineNo": 646,
       "lines": [
         "()"
       ],

--- a/lib/test/cases/indent-mode.json
+++ b/lib/test/cases/indent-mode.json
@@ -854,7 +854,7 @@
       "fileLineNo": 564,
       "lines": [
         "(let [a 1]",
-        "   )"
+        "  )"
       ],
       "cursor": {
         "cursorX": 1,
@@ -866,7 +866,7 @@
       "fileLineNo": 570,
       "lines": [
         "(let [a 1]",
-        " )"
+        " ) "
       ],
       "cursor": {
         "cursorX": 1,
@@ -876,32 +876,34 @@
   },
   {
     "in": {
-      "fileLineNo": 577,
+      "fileLineNo": 578,
       "lines": [
         "(let [a 1]",
-        " )"
+        "",
+        "  (+ a 2))"
       ],
       "cursor": {
-        "cursorX": 2,
+        "cursorX": 0,
         "cursorLine": 1,
         "previewCursorScope": true
       }
     },
     "out": {
-      "fileLineNo": 583,
+      "fileLineNo": 585,
       "lines": [
         "(let [a 1]",
-        "  )"
+        "",
+        "  (+ a 2))"
       ],
       "cursor": {
-        "cursorX": 2,
+        "cursorX": 0,
         "cursorLine": 1
       }
     }
   },
   {
     "in": {
-      "fileLineNo": 591,
+      "fileLineNo": 594,
       "lines": [
         "(let [a 1",
         "      ] b)"
@@ -913,7 +915,7 @@
       }
     },
     "out": {
-      "fileLineNo": 597,
+      "fileLineNo": 600,
       "lines": [
         "(let [a 1",
         "       b])"
@@ -926,7 +928,7 @@
   },
   {
     "in": {
-      "fileLineNo": 610,
+      "fileLineNo": 613,
       "lines": [
         "(foo ]] bar)"
       ],
@@ -936,7 +938,7 @@
       }
     },
     "out": {
-      "fileLineNo": 614,
+      "fileLineNo": 617,
       "lines": [
         "(foo  bar)"
       ],
@@ -948,7 +950,7 @@
   },
   {
     "in": {
-      "fileLineNo": 620,
+      "fileLineNo": 623,
       "lines": [
         "(foo bar ;)"
       ],
@@ -958,7 +960,7 @@
       }
     },
     "out": {
-      "fileLineNo": 624,
+      "fileLineNo": 627,
       "lines": [
         "(foo bar) ;)"
       ],
@@ -970,7 +972,7 @@
   },
   {
     "in": {
-      "fileLineNo": 630,
+      "fileLineNo": 633,
       "lines": [
         "(let [x 1",
         "      y 2;])"
@@ -981,7 +983,7 @@
       }
     },
     "out": {
-      "fileLineNo": 635,
+      "fileLineNo": 638,
       "lines": [
         "(let [x 1",
         "      y 2]);])"
@@ -994,7 +996,7 @@
   },
   {
     "in": {
-      "fileLineNo": 642,
+      "fileLineNo": 645,
       "lines": [
         "("
       ],
@@ -1004,7 +1006,7 @@
       }
     },
     "out": {
-      "fileLineNo": 646,
+      "fileLineNo": 649,
       "lines": [
         "()"
       ],

--- a/lib/test/cases/indent-mode.json
+++ b/lib/test/cases/indent-mode.json
@@ -854,7 +854,7 @@
       "fileLineNo": 564,
       "lines": [
         "(let [a 1]",
-        "  )"
+        "   )"
       ],
       "cursor": {
         "cursorX": 1,

--- a/lib/test/cases/indent-mode.json
+++ b/lib/test/cases/indent-mode.json
@@ -645,7 +645,7 @@
   },
   {
     "in": {
-      "fileLineNo": 443,
+      "fileLineNo": 445,
       "lines": [
         "(let [a 1])",
         "  ret)"
@@ -653,7 +653,7 @@
       "cursor": null
     },
     "out": {
-      "fileLineNo": 448,
+      "fileLineNo": 450,
       "lines": [
         "(let [a 1]",
         "  ret)"
@@ -663,7 +663,7 @@
   },
   {
     "in": {
-      "fileLineNo": 455,
+      "fileLineNo": 457,
       "lines": [
         "(let [a 1])",
         "  ret)"
@@ -674,7 +674,7 @@
       }
     },
     "out": {
-      "fileLineNo": 460,
+      "fileLineNo": 462,
       "lines": [
         "(let [a 1])",
         "  ret"
@@ -687,7 +687,7 @@
   },
   {
     "in": {
-      "fileLineNo": 468,
+      "fileLineNo": 470,
       "lines": [
         "(let [a 1]) 2",
         "  ret"
@@ -695,7 +695,7 @@
       "cursor": null
     },
     "out": {
-      "fileLineNo": 473,
+      "fileLineNo": 475,
       "lines": [
         "(let [a 1]) 2",
         "  ret"
@@ -705,7 +705,7 @@
   },
   {
     "in": {
-      "fileLineNo": 481,
+      "fileLineNo": 483,
       "lines": [
         "(let [a 1])",
         "  ret)"
@@ -716,7 +716,7 @@
       }
     },
     "out": {
-      "fileLineNo": 486,
+      "fileLineNo": 488,
       "lines": [
         "(let [a 1]",
         "  ret)"
@@ -729,7 +729,7 @@
   },
   {
     "in": {
-      "fileLineNo": 493,
+      "fileLineNo": 495,
       "lines": [
         "(let [a 1]) ;",
         "  ret"
@@ -740,7 +740,7 @@
       }
     },
     "out": {
-      "fileLineNo": 498,
+      "fileLineNo": 500,
       "lines": [
         "(let [a 1] ;",
         "  ret)"
@@ -753,7 +753,7 @@
   },
   {
     "in": {
-      "fileLineNo": 507,
+      "fileLineNo": 511,
       "lines": [
         "(let [a 1",
         "      ])"
@@ -764,7 +764,7 @@
       }
     },
     "out": {
-      "fileLineNo": 512,
+      "fileLineNo": 516,
       "lines": [
         "(let [a 1])",
         "      "
@@ -777,7 +777,131 @@
   },
   {
     "in": {
-      "fileLineNo": 519,
+      "fileLineNo": 523,
+      "lines": [
+        "(let [a 1])",
+        "      b"
+      ],
+      "cursor": {
+        "cursorX": 7,
+        "cursorLine": 1
+      }
+    },
+    "out": {
+      "fileLineNo": 528,
+      "lines": [
+        "(let [a 1",
+        "      b])"
+      ],
+      "cursor": {
+        "cursorX": 7,
+        "cursorLine": 1
+      }
+    }
+  },
+  {
+    "in": {
+      "fileLineNo": 537,
+      "lines": [
+        "(let [a 1",
+        "      ])"
+      ],
+      "cursor": {
+        "cursorX": 6,
+        "cursorLine": 1,
+        "previewCursorScope": true
+      }
+    },
+    "out": {
+      "fileLineNo": 543,
+      "lines": [
+        "(let [a 1",
+        "      ])"
+      ],
+      "cursor": {
+        "cursorX": 6,
+        "cursorLine": 1
+      }
+    }
+  },
+  {
+    "in": {
+      "fileLineNo": 551,
+      "lines": [
+        "(let [a 1])",
+        "  "
+      ],
+      "cursor": {
+        "cursorX": 2,
+        "cursorLine": 1,
+        "previewCursorScope": true
+      }
+    },
+    "out": {
+      "fileLineNo": 557,
+      "lines": [
+        "(let [a 1]",
+        "  )"
+      ],
+      "cursor": {
+        "cursorX": 2,
+        "cursorLine": 1
+      }
+    }
+  },
+  {
+    "in": {
+      "fileLineNo": 564,
+      "lines": [
+        "(let [a 1]",
+        "  )"
+      ],
+      "cursor": {
+        "cursorX": 1,
+        "cursorLine": 1,
+        "previewCursorScope": true
+      }
+    },
+    "out": {
+      "fileLineNo": 570,
+      "lines": [
+        "(let [a 1]",
+        " )"
+      ],
+      "cursor": {
+        "cursorX": 1,
+        "cursorLine": 1
+      }
+    }
+  },
+  {
+    "in": {
+      "fileLineNo": 578,
+      "lines": [
+        "(let [a 1",
+        "      ] b)"
+      ],
+      "cursor": {
+        "cursorX": 6,
+        "cursorLine": 1,
+        "previewCursorScope": true
+      }
+    },
+    "out": {
+      "fileLineNo": 584,
+      "lines": [
+        "(let [a 1",
+        "       b])"
+      ],
+      "cursor": {
+        "cursorX": 6,
+        "cursorLine": 1
+      }
+    }
+  },
+  {
+    "in": {
+      "fileLineNo": 597,
       "lines": [
         "(foo ]] bar)"
       ],
@@ -787,7 +911,7 @@
       }
     },
     "out": {
-      "fileLineNo": 523,
+      "fileLineNo": 601,
       "lines": [
         "(foo  bar)"
       ],
@@ -799,7 +923,7 @@
   },
   {
     "in": {
-      "fileLineNo": 529,
+      "fileLineNo": 607,
       "lines": [
         "(foo bar ;)"
       ],
@@ -809,7 +933,7 @@
       }
     },
     "out": {
-      "fileLineNo": 533,
+      "fileLineNo": 611,
       "lines": [
         "(foo bar) ;)"
       ],
@@ -821,7 +945,7 @@
   },
   {
     "in": {
-      "fileLineNo": 539,
+      "fileLineNo": 617,
       "lines": [
         "(let [x 1",
         "      y 2;])"
@@ -832,7 +956,7 @@
       }
     },
     "out": {
-      "fileLineNo": 544,
+      "fileLineNo": 622,
       "lines": [
         "(let [x 1",
         "      y 2]);])"
@@ -845,7 +969,7 @@
   },
   {
     "in": {
-      "fileLineNo": 551,
+      "fileLineNo": 629,
       "lines": [
         "("
       ],
@@ -855,7 +979,7 @@
       }
     },
     "out": {
-      "fileLineNo": 555,
+      "fileLineNo": 633,
       "lines": [
         "()"
       ],

--- a/lib/test/cases/indent-mode.md
+++ b/lib/test/cases/indent-mode.md
@@ -379,7 +379,7 @@ escape character in comment untouched:
 
 ---
 
-## Cursor Cases
+## Cursor Padding in Paren Trail
 
 __NOTE__: the pipe `|` represents the cursor, but the character is removed from the input.
 
@@ -434,6 +434,8 @@ cursor is to the left of the gaps.
 ```out
 (def |b [[c d]])
 ```
+
+## Cursor Blocking displacement of Paren Trail
 
 Inferred close-parens before the cursor are never removed, which may
 cause indented lines below to be ignored.  This is to allow inserting a token
@@ -501,6 +503,8 @@ If the cursor is in a comment after such a close-paren, we can safely move it:
   ret)
 ```
 
+## Cursor Behind Standalone Close-Parens
+
 It is common to press enter when the cursor is the left of a close-paren.
 Since a line cannot start with a close-paren, they are moved back to where
 they were.
@@ -514,6 +518,80 @@ they were.
 (let [a 1])
       |
 ```
+
+The close-parens will move back once you start typing something:
+
+```in
+(let [a 1])
+      b|
+```
+
+```out
+(let [a 1
+      b|])
+```
+
+Some may prefer to allow the parentheses to stay after the cursor even before
+typing.  Thus, you can enable a `previewCursorScope` option that will allow you
+to preview where the Paren Trail would be after inserting text at the cursor.
+
+```in
+(let [a 1
+      |])
+      ^ previewCursorScope
+```
+
+```out
+(let [a 1
+      |])
+```
+
+If you place the cursor on an empty line, `previewCursorScope` will allow you
+to see where the paren trail will go, revealing the cursor's current scope.
+
+```in
+(let [a 1])
+  |
+  ^ previewCursorScope
+```
+
+```out
+(let [a 1]
+  |)
+```
+
+Moving the cursor back will adjust the scope.
+
+```in
+(let [a 1]
+ | )
+ ^ previewCursorScope
+```
+
+```out
+(let [a 1]
+ |)
+```
+
+The same rules do not apply for the following example
+because it represents an unstable code state.
+
+```in
+(let [a 1
+      |] b)
+      ^ previewCursorScope
+```
+
+```out
+(let [a 1
+      | b])
+```
+
+This is expected behavior, but the common path to this state (i.e. pressing
+enter at `(let [a 1|] b)`) is handled using an explicit action external to
+Indent Mode.
+
+## Cursor Shifting
 
 Removing invalid close-parens should pull back the cursor
 

--- a/lib/test/cases/indent-mode.md
+++ b/lib/test/cases/indent-mode.md
@@ -564,7 +564,7 @@ Moving the cursor back will adjust the scope.
 
 ```in
 (let [a 1]
- | )
+ |  )
  ^ previewCursorScope
 ```
 

--- a/lib/test/cases/indent-mode.md
+++ b/lib/test/cases/indent-mode.md
@@ -564,30 +564,33 @@ Moving the cursor back will adjust the scope.
 
 ```in
 (let [a 1]
- |  )
+ | )
  ^ previewCursorScope
 ```
 
 ```out
 (let [a 1]
- |)
+ |) 
 ```
 
-Moving the cursor forward will adjust the scope.
+The following will not preview cursor scope, because doing so
+will change the AST.
 
 ```in
 (let [a 1]
- )|
-  ^ previewCursorScope
+|
+^ previewCursorScope
+  (+ a 2))
 ```
 
 ```out
 (let [a 1]
-  |)
+|
+  (+ a 2))
 ```
 
-The same rules do not apply for the following example
-because it represents an unstable code state.
+This also does not mean we can hold all leading close-parens
+in place.  The following example represents an unsupported case:
 
 ```in
 (let [a 1

--- a/lib/test/cases/indent-mode.md
+++ b/lib/test/cases/indent-mode.md
@@ -573,6 +573,19 @@ Moving the cursor back will adjust the scope.
  |)
 ```
 
+Moving the cursor forward will adjust the scope.
+
+```in
+(let [a 1]
+ )|
+  ^ previewCursorScope
+```
+
+```out
+(let [a 1]
+  |)
+```
+
 The same rules do not apply for the following example
 because it represents an unstable code state.
 

--- a/lib/update-doc-reflinks.sh
+++ b/lib/update-doc-reflinks.sh
@@ -22,6 +22,9 @@ docfile=parinfer.js.md
 # ref links for each function name
 fn_links=$(perl -n -e'/^function (\w+)/ && print "[`$1`]:parinfer.js#L$.\n"' $srcfile)
 
+# ref links for each var name
+var_links=$(perl -n -e'/^var ([\w_]+) = / && print "[`$1`]:parinfer.js#L$.\n"' $srcfile)
+
 # ref links for each top-level result key
 result_links=$(perl -n -e'm{^    (\w+):.*//} && print "[`result.$1`]:parinfer.js#L$.\n"' $srcfile)
 
@@ -30,4 +33,4 @@ lineno=$(perl -n -e'/<!-- END OF DOC/ && print $.' $docfile)
 
 # add ref links to the docs
 docs=$(head -n $lineno $docfile)
-printf "$docs\n$fn_links\n$result_links" > $docfile
+printf "$docs\n$var_links\n$fn_links\n$result_links" > $docfile


### PR DESCRIPTION
In preparation for auto-indent in atom-parinfer, I started understanding the problem space around new line insertion, and ended up formalizing a simple new cursor rule that can help UX.

If `previewCursorScope` is enabled in Indent Mode, then this...

``` clj
(let [foo 1
       bar 2])
  |
```

...will look like this:

``` clj
(let [foo 1
       bar 2]
  |)
```

I thought about this last year and didn't think it could be done in a manner consistent to Parinfer's rules. But it seems solid now.  [Full details in new design doc section](https://github.com/shaunlebron/parinfer/blob/cursor-scope/lib/parinfer.js.md#seeing-cursor-scope-in-indent-mode)

_This will also enable easier drawing in the Parinfer Next experiment._
