### PR TITLE
Fix for #173

### DIFF
--- a/lib/parinfer.js
+++ b/lib/parinfer.js
@@ -870,7 +870,8 @@ function getParentOpenerIndex(result, indentX) {
   for (i=0; i<result.parenStack.length; i++) {
     var opener = peek(result.parenStack, i);
     var currOutside = (opener.x < indentX);
-    var prevOutside = (opener.x - opener.indentDelta < indentX);
+    var lineIndentDelta = Math.max(0, result.indentDelta);
+    var prevOutside = (opener.x - opener.indentDelta + lineIndentDelta < indentX);
 
     if (prevOutside) {
       // If an open-paren WAS outside, its `indentDelta` will be used to KEEP IT

--- a/lib/parinfer.js
+++ b/lib/parinfer.js
@@ -442,10 +442,9 @@ function insertWithinLine(result, lineNo, idx, insert) {
   replaceWithinLine(result, lineNo, idx, idx, insert);
 }
 
-function initLine(result, line) {
+function initLine(result) {
   result.x = 0;
   result.lineNo++;
-  result.lines.push(line);
 
   // reset line-specific state
   result.indentX = UINT_NULL;
@@ -1253,7 +1252,8 @@ function processChar(result, ch) {
 }
 
 function processLine(result, lineNo) {
-  initLine(result, result.inputLines[lineNo]);
+  initLine(result);
+  result.lines.push(result.inputLines[lineNo]);
 
   setTabStops(result);
 
@@ -1284,7 +1284,7 @@ function finalizeResult(result) {
     }
   }
   if (result.mode === INDENT_MODE) {
-    result.x = 0;
+    initLine(result);
     onIndent(result);
   }
   result.success = true;

--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -9,8 +9,39 @@ const parinferTest = require('./test');
 const parinfer = require('./parinfer');
 
 const code = `
-(let [a 1
-      ]|)
+((reduce-kv (fn [m k v])
+            {}
+            {}))
 `;
 
-console.log(parinferTest.smartMode(code, {printParensOnly: true}));
+console.log(parinfer.smartMode(code, {
+  changes: [
+    {lineNo:1, x:0, oldText: '', newText: '('},
+    {lineNo:2, x:11, oldText: '', newText: ' '},
+    {lineNo:3, x:11, oldText: '', newText: ' '},
+    {lineNo:3, x:15, oldText: '', newText: ')'},
+  ],
+}).text);
+
+// TODO: this should become a test case, but the current test parser
+// does not allow it - it returns an error: "diff chars must be adjacent"
+// My JS regexp-fu is not up to fixing that, sorry.
+
+// Here's what the test case looks like:
+
+// Form is indented by editor when wrapping with parens:
+//
+// ```in
+// ((reduce-kv (fn [m k v]
+// +
+//             {}
+//            +
+//             {})))
+//            +    +
+// ```
+//
+//   ```out
+// ((reduce-kv (fn [m k v]
+//             {}
+//             {})))
+// ```


### PR DESCRIPTION
This contains a fix for #173. I'd appreciate a review, since I'm not 100% sure this is the right fix. However it does fix that case and pass all existing tests.

The basic problem that when correcting the paren trail, the current line indent delta was not taken into account, only the opener indent delta. I must admit that I don't fully understand the subtleties of what `getParentOpenerIndex` is doing. Additionally, this is only taken into account when indenting, not dedenting - again, I'm not sure if this is the right solution, but it works for all the existing cases and #173.

I created a test case, but the current test case parser only allows a single change per line. I've left the case from #173 with the markdown for what the test case should look like in the sandbox.